### PR TITLE
Switched to shared SQLite cache

### DIFF
--- a/pkg/coco/city.go
+++ b/pkg/coco/city.go
@@ -199,7 +199,7 @@ func (c *CityDB) loadData() {
 }
 
 func (c *CityDB) createMemDB() *sql.DB {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite3", "file::memory:?cache=shared")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
A shared SQLite cache allows us to query the in-memory database with multiple go routines without running into "table not found" error
